### PR TITLE
Improving build on Mac and Linux

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,6 +57,14 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line be updated
+# automatically.
+/usr/bin/sudo -n yum install -y devtoolset-2-gcc-gfortran
+
+
 conda build /recipe_root --quiet || exit 1
 upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,13 @@
 if [ "$(uname)" == "Darwin" ]; then
     
     cd build
-    cmake -DCMAKE_{C,CXX}_FLAGS="-arch x86_64" -DCMAKE_Fortran_FLAGS="-m64" -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_RPATH="${PREFIX}/lib" -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE -DCMAKE_EXE_LINKER_FLAGS='-headerpad_max_install_names' ..
+    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DLAPACK_LIBRARIES=${PREFIX}/lib/liblapack.dylib -DBLAS_LIBRARIES=${PREFIX}/lib/libcblas.dylib \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_C_FLAGS=${CFLAGS} \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_CXX_FLAGS=${CXXFLAGS} \
+          -DCMAKE_CXX_STANDARD=98 \
+          ..
     make
     make install
     

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://github.com/JohannesBuchner/MultiNest
 
 build:
-   number: 2
+   number: 0
    skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://github.com/JohannesBuchner/MultiNest
 
 build:
-   number: 1
+   number: 2
    skip: true  # [win]
 
 requirements:
@@ -15,27 +15,32 @@ requirements:
     - toolchain
     - cmake
     - lapack
-    - gcc
-    - libgfortran
+    - openblas
+    - gcc  # [osx]
+    - libgfortran  # [linux]
     - mpich
 
   run:
     - lapack
+    - openblas
     - mpich
-    - libgcc
     - libgfortran
 
 test:
   commands:
-    - bash -c "cd ${PREFIX}/bin ; gaussian"
+    - bash -c "cd ${PREFIX}/bin ; mkdir chains ; gaussian"
     - test -f ${PREFIX}/lib/libmultinest.so  # [linux]
     
     - test -f ${PREFIX}/lib/libmultinest.dylib  # [osx]
     
     - test -f ${PREFIX}/include/multinest.h
+    - python -c "import pymultinest"
     
     - conda inspect linkages --show-files -p $PREFIX multinest  # [not win]
     - conda inspect objects -p $PREFIX multinest  # [osx]
+  
+  requires:
+    - pymultinest
 
 
 about:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+devtoolset-2-gcc-gfortran


### PR DESCRIPTION
Now using the proper way of compiling under Mac, and using the `yum_requirements.txt` on Linux as `wcslib` so we do not need to install `gcc`.